### PR TITLE
Implemented nullable and fix for simultaneous calls to ResizeGrid

### DIFF
--- a/Blazm.Components/Blazm.Components.Tests/Blazm.Components.Tests.csproj
+++ b/Blazm.Components/Blazm.Components.Tests/Blazm.Components.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.14.0" />
-    <PackageReference Include="bunit" Version="1.0.0-preview-01-g8235d9370f" />
+    <PackageReference Include="bunit" Version="1.0.0-preview-01-gf1c95e2f14" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Blazm.Components/Blazm.Components/Blazm.Components.csproj
+++ b/Blazm.Components/Blazm.Components/Blazm.Components.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <RazorLangVersion>5.0</RazorLangVersion>
-    <LangVersion>9</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Authors>Jimmy Engström</Authors>
     <Description>A collection of Blazor components</Description>
-    <Version>0.0.18</Version>
+    <Version>0.0.19</Version>
+	  <Nullable>enable</Nullable>
     <PackageProjectUrl>https://github.com/EngstromJimmy/Blazm.Components</PackageProjectUrl>
     <RepositoryUrl>https://github.com/EngstromJimmy/Blazm.Components</RepositoryUrl>
     <PackageTags>moved</PackageTags>

--- a/Blazm.Components/Blazm.Components/Dynamic/ExpandoObjectTypeDescriptor.cs
+++ b/Blazm.Components/Blazm.Components/Dynamic/ExpandoObjectTypeDescriptor.cs
@@ -12,7 +12,7 @@ namespace Blazm.Components.Dynamic
 
         public ExpandoObjectTypeDescriptor(dynamic instance)
         {
-            m_Instance = instance as IDictionary<string, object>;
+            m_Instance = instance as IDictionary<string, object> ?? new Dictionary<string, object>();
         }
 
         public string GetComponentName()
@@ -60,7 +60,7 @@ namespace Blazm.Components.Dynamic
             return TypeDescriptor.GetEditor(this, editorBaseType, true);
         }
 
-        public PropertyDescriptor GetDefaultProperty()
+        public PropertyDescriptor? GetDefaultProperty()
         {
             return null;
         }
@@ -113,7 +113,7 @@ namespace Blazm.Components.Dynamic
                 }
             }
 
-            public override Type ComponentType
+            public override Type? ComponentType
             {
                 get { return null; }
             }

--- a/Blazm.Components/Blazm.Components/Extensions/NavigationManagerExtensions.cs
+++ b/Blazm.Components/Blazm.Components/Extensions/NavigationManagerExtensions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.AspNetCore.Components
 {
     public static class NavigationManagerExtensions
     {
-        static IJSObjectReference windowmodule;
+        static IJSObjectReference windowmodule = default!;
 
         public static async Task NavigateToNewWindowAsync(this NavigationManager navigator, IJSRuntime jsRuntime, string url, string content)
         {

--- a/Blazm.Components/Blazm.Components/Grid/BlazmGrid.razor.cs
+++ b/Blazm.Components/Blazm.Components/Grid/BlazmGrid.razor.cs
@@ -76,7 +76,7 @@ namespace Blazm.Components
         } = false;
 
         [Parameter]
-        public string SortField
+        public string? SortField
         {
             get;
             set;
@@ -91,7 +91,7 @@ namespace Blazm.Components
 
 
         [Parameter]
-        public string GroupSortField
+        public string? GroupSortField
         {
             get;
             set;
@@ -108,7 +108,7 @@ namespace Blazm.Components
         {
             get;
             set;
-        }
+        } = default!;
 
 
         [Parameter]
@@ -116,16 +116,14 @@ namespace Blazm.Components
         {
             get;
             set;
-        }
+        } = default!;
 
         [Parameter]
         public RenderFragment NullGridTemplate
         {
             get;
             set;
-        }
-
-
+        } = default!;
 
 
         [Parameter]
@@ -133,14 +131,14 @@ namespace Blazm.Components
         {
             get;
             set;
-        }
+        } = default!;
 
 
         [Parameter]
-        public Func<TItem, object> GroupBy { get; set; } = null;
+        public Func<TItem, object>? GroupBy { get; set; } = null;
 
         [Parameter]
-        public ItemsProviderDelegate<TItem> ItemsProvider { get; set; }
+        public ItemsProviderDelegate<TItem> ItemsProvider { get; set; } = default!;
 
         [Parameter]
         public IEnumerable<TItem>? Data { get; set; }
@@ -150,8 +148,8 @@ namespace Blazm.Components
 
         #endregion
 
-        [Inject] ResizeListener listener { get; set; }
-        [Inject] IJSRuntime jsruntime { get; set; }
+        [Inject] ResizeListener listener { get; set; } = default!;
+        [Inject] IJSRuntime jsruntime { get; set; } = default!;
 
         private bool ShowAllColumns { get; set; }
         private List<IGridColumn> Columns { get; set; } = new List<IGridColumn>();
@@ -160,8 +158,8 @@ namespace Blazm.Components
         string id = Guid.NewGuid().ToString();
         int ContainerClientWidth { get; set; }
         int TableClientWidth { get; set; }
-        private Virtualize<TItem> virtualize { get; set; }
-        private IEnumerable<TItem> pagedData { get; set; }
+        private Virtualize<TItem> virtualize { get; set; } = default!;
+        private IEnumerable<TItem> pagedData { get; set; } = default!;
 
         protected override async  Task OnParametersSetAsync()
         {
@@ -189,11 +187,11 @@ namespace Blazm.Components
                 {
                     if (SortDirection == ListSortDirection.Descending)
                     {
-                        pagedData = pagedData.OrderByDescending(x => x.GetType().GetProperty(SortField).GetValue(x, null)).ToList();
+                        pagedData = pagedData.OrderByDescending(x => x.GetType().GetProperty(SortField)?.GetValue(x, null)).ToList();
                     }
                     else
                     {
-                        pagedData = pagedData.OrderBy(x => x.GetType().GetProperty(SortField).GetValue(x, null)).ToList();
+                        pagedData = pagedData.OrderBy(x => x.GetType().GetProperty(SortField)?.GetValue(x, null)).ToList();
                     }
                 }
 
@@ -470,59 +468,75 @@ namespace Blazm.Components
             listener.OnResized -= WindowResized;
         }
 
+        private bool resizing = false;
+        private bool resizeAgain = false;
+
         async void WindowResized(object _, BrowserWindowSize window)
         {
-            await ResizeGrid();
+            if (!resizing)
+            {
+                await ResizeGrid();
+            }
+            else
+            {
+                resizeAgain = true;
+            }
         }
 
 
-        IJSObjectReference resizemodule;
+        IJSObjectReference resizemodule = default!;
         public async Task ResizeGrid()
         {
-            try
+            do
             {
-                resizemodule = await jsruntime.InvokeAsync<IJSObjectReference>("import", "/_content/Blazm.Components/scripts/ResizeTable.js");
-                ShowAllColumns = true;
-                StateHasChanged();
-
-                var size = await resizemodule.InvokeAsync<TableSize>("ResizeTable", id, GroupBy != null);
-
-                ShowAllColumns = false;
-                StateHasChanged();
-
-                if (size != null)
+                try
                 {
-                    for (var i = 0; i < size?.Columns?.Length; i++)
+                    resizing = true;
+                    resizeAgain = false;
+                    resizemodule = await jsruntime.InvokeAsync<IJSObjectReference>("import", "/_content/Blazm.Components/scripts/ResizeTable.js");
+                    ShowAllColumns = true;
+                    await InvokeAsync(StateHasChanged);
+
+                    var size = await resizemodule.InvokeAsync<TableSize>("ResizeTable", id, GroupBy != null);
+
+                    ShowAllColumns = false;
+                    await InvokeAsync(StateHasChanged);
+
+                    if (size != null)
                     {
-                        var counter = i;
-                        if (ShowCheckbox || Columns.Any(c => !c.Visible))
+                        for (var i = 0; i < size?.Columns?.Length; i++)
                         {
-                            //Skip the first one
-                            counter = i - 1;
-                            if (i == 0)
+                            var counter = i;
+                            if (ShowCheckbox || Columns.Any(c => !c.Visible))
                             {
-                                continue;
+                                //Skip the first one
+                                counter = i - 1;
+                                if (i == 0)
+                                {
+                                    continue;
+                                }
                             }
+                            Columns[counter].ClientWidth = size.Columns[i];
                         }
-                        Columns[counter].ClientWidth = size.Columns[i];
+                        TableClientWidth = size.TableClientWidth;
+                        ContainerClientWidth = size.ContainerClientWidth;
+
+                        await resizeTableAsync();
+
+                        await InvokeAsync(StateHasChanged);
                     }
-                    TableClientWidth = size.TableClientWidth;
-                    ContainerClientWidth = size.ContainerClientWidth;
-
-                    await resizeTableAsync();
-
-                    StateHasChanged();
+                }
+                finally
+                {
+                    resizing = false;
                 }
             }
-            catch (Exception ex)
-            { 
-
-            }
+            while (resizeAgain);
         }
 
         class TableSize
         {
-            public int[] Columns { get; set; }
+            public int[] Columns { get; set; } = Array.Empty<int>();
             public int TableClientWidth { get; set; }
             public int ContainerClientWidth { get; set; }
         }

--- a/Blazm.Components/Blazm.Components/Grid/HiddenRows.razor
+++ b/Blazm.Components/Blazm.Components/Grid/HiddenRows.razor
@@ -15,11 +15,11 @@
                         {
                             @if (hiddencolumn.Format == null)
                             {
-                                @Row.GetType().GetProperty(hiddencolumn.Field).GetValue(Row)
+                                @Row.GetType().GetProperty(hiddencolumn.Field)?.GetValue(Row)
                             }
                             else
                             {
-                                @string.Format(hiddencolumn.Format, Row.GetType().GetProperty(hiddencolumn.Field).GetValue(Row))
+                                @string.Format(hiddencolumn.Format, Row.GetType().GetProperty(hiddencolumn.Field)?.GetValue(Row))
                             }
                         }
                         else
@@ -38,7 +38,7 @@
     [Parameter]
     public List<int> ExpandedRows { get; set; } = new List<int>();
     [Parameter]
-    public TItem Row { get; set; }
+    public TItem Row { get; set; } = default!;
     [Parameter]
     public bool ShowCheckbox { get; set; }
 

--- a/Blazm.Components/SampleServerSide/Pages/FetchDataVirtualize.razor
+++ b/Blazm.Components/SampleServerSide/Pages/FetchDataVirtualize.razor
@@ -40,7 +40,6 @@
 
 @code {
     private WeatherForecast[] forecasts;
-    private BlazmGrid<WeatherForecast> GroupedGrid;
     protected override async Task OnInitializedAsync()
     {
         forecasts = await ForecastService.GetForecastAsync(DateTime.Now,500);

--- a/Blazm.Components/SampleServerSide/Pages/GridAutoGenerateDynamic.razor
+++ b/Blazm.Components/SampleServerSide/Pages/GridAutoGenerateDynamic.razor
@@ -30,12 +30,12 @@ else
 @code {
     private List<dynamic> forecasts;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        await Load();
+        Load();
     }
 
-    protected async Task Load(DateTime? date = null)
+    protected void Load(DateTime? date = null)
     {
         forecasts = new List<dynamic>();
         for (int i= 0; i < 30; i++)

--- a/Blazm.Components/SampleServerSide/Pages/GridDataColumn.razor
+++ b/Blazm.Components/SampleServerSide/Pages/GridDataColumn.razor
@@ -47,7 +47,7 @@ else
                     @{
                         var item = context as WeatherForecast;
                     }
-                    <button class="btn btn-danger" @onclick="@(async () => { await Delete(item); })"><i class="far fa-trash-alt"></i></button>
+                    <button class="btn btn-danger" @onclick="@(() => { Delete(item); })"><i class="far fa-trash-alt"></i></button>
                 </Template>
             </GridColumn>
         </GridColumns>
@@ -64,7 +64,7 @@ else
         await Load();
     }
 
-    protected async Task Delete(WeatherForecast item)
+    protected void Delete(WeatherForecast item)
     {
         forecasts.Remove(item);
     }

--- a/Blazm.Components/SampleServerSide/Pages/GridDataColumnNoRows.razor
+++ b/Blazm.Components/SampleServerSide/Pages/GridDataColumnNoRows.razor
@@ -50,7 +50,7 @@ else
                     @{
                         var item = context as WeatherForecast;
                     }
-                    <button class="btn btn-danger" @onclick="@(async () => { await Delete(item); })"><i class="far fa-trash-alt"></i></button>
+                    <button class="btn btn-danger" @onclick="@(() => { Delete(item); })"><i class="far fa-trash-alt"></i></button>
                 </Template>
             </GridColumn>
         </GridColumns>
@@ -62,17 +62,17 @@ else
     private List<WeatherForecast> forecasts;
     private BlazmGrid<WeatherForecast> MyGrid;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        await Load();
+        Load();
     }
 
-    protected async Task Delete(WeatherForecast item)
+    protected void Delete(WeatherForecast item)
     {
         forecasts.Remove(item);
     }
 
-    protected async Task Load(DateTime? date = null)
+    protected void Load(DateTime? date = null)
     {
         forecasts = new List<WeatherForecast>() ;
     }

--- a/Blazm.Components/SampleServerSide/Startup.cs
+++ b/Blazm.Components/SampleServerSide/Startup.cs
@@ -1,12 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Blazm.Components;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -32,7 +26,7 @@ namespace SampleServerSide
             services.AddSingleton<WeatherForecastService>();
             
             //<Add grid to services>
-            services.AddGrid();
+            services.AddBlazm();
             //</Add grid to services>
         }
 


### PR DESCRIPTION
Implemented nullable in the project to pick up any loose ends which could cause NullableExceptions. Especially in dynamic grids reading columns and attributes.

ResizeGrid check if already running and reruns if any event is called during resize.