### PR TITLE
Prevent NullReferenceException if specified field does not exist

### DIFF
--- a/Blazm.Components/Blazm.Components/Grid/GridColumn.razor
+++ b/Blazm.Components/Blazm.Components/Grid/GridColumn.razor
@@ -137,7 +137,7 @@
         {
             if (Type != null && Field != null)
             {
-                var displayattribute = TypeDescriptor.GetReflectionType(this.Type).GetProperty(Field).GetCustomAttribute<DisplayAttribute>();
+                var displayattribute = TypeDescriptor.GetReflectionType(this.Type).GetProperty(Field)?.GetCustomAttribute<DisplayAttribute>();
                 if (title == null && displayattribute != null)
                 {
                     this.title = displayattribute.Name;


### PR DESCRIPTION
Since GetProperty(Field) will return `null` in the case when Field does not exist, the null-checking `if` will never be reached and cause a NullReferenceException which will be hard to understand in the consuming code.