### PR TITLE
Fix for if grid has data and then gets empty

### DIFF
--- a/Blazm.Components/Blazm.Components/Grid/BlazmGrid.razor.cs
+++ b/Blazm.Components/Blazm.Components/Grid/BlazmGrid.razor.cs
@@ -214,9 +214,9 @@ namespace Blazm.Components
                 ItemsProvider = LoadData;
             }
 
-            if (Data != null && Data.Count() > 0)
+            if (Data != null)
             {
-                HasData = true;
+                HasData = Data.Any();
                 await RefreshDataAsync();
             }
 


### PR DESCRIPTION
Make sure that the grid is refreshed if data is cleared. Set HasData to Data.Any() instead of using Count().